### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mikevanoo/dotnet-distributed-app/security/code-scanning/1](https://github.com/mikevanoo/dotnet-distributed-app/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block to the workflow to ensure the minimum required permissions for the GITHUB_TOKEN are used. For almost all basic build-and-test pipelines (like this .NET example), read access to contents is sufficient, so the recommended block would be:
```yaml
permissions:
  contents: read
```
Since there is only one job, it's simplest and cleanest to add this block at the workflow root (after the workflow `name` field and before `on:`), making it apply to all jobs unless overridden. 
No new imports, methods, or other definitions are needed — this is a declarative YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
