### PR TITLE
Update xUnit package references to `xunit.v3.mtp-v2` and bump CodeCoverage version in tests configuration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.9" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
@@ -54,6 +54,6 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="xunit.analyzers" Version="1.27.0" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 </Project>

--- a/tests/DotNetDistributedApp.Api.Tests/DotNetDistributedApp.Api.Tests.csproj
+++ b/tests/DotNetDistributedApp.Api.Tests/DotNetDistributedApp.Api.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Net" />

--- a/tests/DotNetDistributedApp.Events.Consumer.Tests/DotNetDistributedApp.Events.Consumer.Tests.csproj
+++ b/tests/DotNetDistributedApp.Events.Consumer.Tests/DotNetDistributedApp.Events.Consumer.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Net" />

--- a/tests/DotNetDistributedApp.IntegrationTests/DotNetDistributedApp.IntegrationTests.csproj
+++ b/tests/DotNetDistributedApp.IntegrationTests/DotNetDistributedApp.IntegrationTests.csproj
@@ -26,7 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Net" />

--- a/tests/DotNetDistributedApp.SpatialApi.Tests/DotNetDistributedApp.SpatialApi.Tests.csproj
+++ b/tests/DotNetDistributedApp.SpatialApi.Tests/DotNetDistributedApp.SpatialApi.Tests.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Net" />


### PR DESCRIPTION
Closes https://github.com/mikevanoo/dotnet-distributed-app/issues/55